### PR TITLE
Add sort by dishtype endpoint and test

### DIFF
--- a/app.spec.js
+++ b/app.spec.js
@@ -180,8 +180,40 @@ describe('api', () => {
       });
     });
   });
-  
-    describe('Test DELETE /api/v1/recipes/:id path', () => {
+
+  describe('Test GET /api/v1/recipes/sort_type path', () => {
+    test('should return a 200 status and recipes sorted alphabetically by dish type', () => {
+      return request(app).get('/api/v1/recipes/sort_type').send(userApiKey).then(response => {
+        expect(response.status).toBe(200);
+        expect(response.body.recipes[0].dishType).toBe('breakfast');
+        expect(response.body.recipes[1].dishType).toBe('dessert');
+        expect(response.body.recipes[3].dishType).toBe('lunch');
+      });
+    });
+
+    test('should return a 401 status if API key is invalid', () => {
+      return request(app).get('/api/v1/recipes/sort_type').send({ 'apiKey': 'invalid_key' }).then(response => {
+        expect(response.status).toBe(401);
+        expect(response.body.message).toBe('Invalid API key');
+      });
+    });
+
+    test('should return a 401 status if API key is not given', () => {
+      return request(app).get('/api/v1/recipes/sort_type').then(response => {
+        expect(response.status).toBe(401);
+        expect(response.body.message).toBe('Invalid API key');
+      });
+    });
+
+    test('should return a 404 status if the user has no recipes saved', () => {
+      return request(app).get('/api/v1/recipes/sort_type').send({ 'apiKey': 'key5' }).then(response => {
+        expect(response.status).toBe(404);
+        expect(response.body.message).toBe('No recipes saved');
+      });
+    });
+  });
+
+  describe('Test DELETE /api/v1/recipes/:id path', () => {
     test('should return a 204 status', () => {
       return request(app).delete('/api/v1/recipes/1').send({'apiKey': 'key1'}).then(response => {
         expect(response.status).toBe(204);

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -191,6 +191,48 @@ router.get('/sort_calories', function(req, res){
   });
 });
 
+// GET recipes sorted by dish type
+router.get('/sort_type', function(req, res){
+  User.findOne({
+    where: { apiKey: req.body.apiKey }
+  })
+  .then(user => {
+    if (user == null) {
+      res.setHeader("Content-Type", "application/json");
+      res.status(401).send(JSON.stringify({ message: "Invalid API key" }));
+    }
+    else {
+      Recipe.findAll({
+        include: {
+            model: UserRecipe,
+            where: { 'UserId': user.id },
+            attributes: []
+          },
+        order: ['dishType'],
+        attributes: { exclude: ['createdAt', 'updatedAt'] }
+      })
+      .then(recipes =>{
+        if (recipes.length == 0) {
+          res.setHeader("Content-Type", "application/json");
+          res.status(404).send(JSON.stringify({ message: "No recipes saved" }));
+        }
+        else {
+          res.setHeader("Content-Type", "application/json");
+          res.status(200).send({ recipes });
+        }
+      })
+      .catch(error => {
+        res.setHeader("Content-Type", "application/json");
+        res.status(400).send({ error });
+      })
+    }
+  })
+  .catch(error => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(401).send(JSON.stringify({ message: "Invalid API key" }));
+  });
+});
+
 // Helper Functions
 function getRecipe(dish_type, search_query) {
   var url = `https://api.edamam.com/search?q=${search_query}&app_id=${process.env.app_id}&app_key=${process.env.app_key}&dish_type=${dish_type}`


### PR DESCRIPTION
Users can get a list of their favorite recipes sorted by dish type by making a GET request to /api/v1/recipes/sort_type with a body containing the user's API key 